### PR TITLE
Fix build with cabal-install-3.10

### DIFF
--- a/vty-unix.cabal
+++ b/vty-unix.cabal
@@ -17,8 +17,8 @@ library
     import:           warnings
     hs-source-dirs:   src
     default-language: Haskell2010
+    includes:         cbits/gwinsz.h
     c-sources:        cbits/set_term_timing.c
-                      cbits/gwinsz.h
                       cbits/gwinsz.c
     exposed-modules:  Data.Terminfo.Eval
                       Data.Terminfo.Parse


### PR DESCRIPTION
It seems to get confused by the .h file in c-sources and fails with:

```
Warning: the following files would be used as linker inputs, but linking is not being done: cbits/gwinsz.h
ghc: no input files
```