### PR TITLE
Make vty-unix-build-width-table more robust

### DIFF
--- a/tools/BuildWidthTable.hs
+++ b/tools/BuildWidthTable.hs
@@ -1,18 +1,29 @@
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE CPP #-}
-module Main where
-
-import System.Console.ANSI (getCursorPosition)
-import Text.Printf (printf)
+module Main (main) where
 
 import Graphics.Vty.UnicodeWidthTable.Main (defaultMain)
-
-charWidth :: Char -> IO Int
-charWidth c = do
-    printf "\r"
-    putChar c
-    Just (_, col) <- getCursorPosition
-    return col
+import System.Console.ANSI (getCursorPosition)
 
 main :: IO ()
 main = defaultMain charWidth
+
+-- | The number of times we'll attempt to compute a character's width
+-- before defaulting to @1@ and continuing.
+attempts :: Int
+attempts = 3
+
+-- | Experimentally determine the console width of the character.
+charWidth :: Char -> IO Int
+charWidth = charWidth' 0
+
+-- | Helper for 'charWidth' with the number of failed attempts counted.
+charWidth' :: Int {- ^ failed attempts -} -> Char -> IO Int
+charWidth' n c
+    | n >= attempts =
+     do putStrLn ("\rUnable to check: " ++ [c] ++ " (" ++ show c ++ ")")
+        pure 1 -- fallback default to 1
+    | otherwise =
+     do putStr ['\r', c]
+        mb <- getCursorPosition
+        case mb of
+            Nothing -> charWidth' (n+1) c
+            Just (_, col) -> pure col


### PR DESCRIPTION
Previously, the tool could fail if the terminal failed to recognize the getCursorPosition escape sequence. This failure mode is uncommon in general but seems to happen occasional in my testing.

The new mitigating logic is to retry a few times before defaulting to width 1 and moving on. A warning is printed to the terminal when this happens.